### PR TITLE
Adding SetFieldKey Function and Corresponding Tests

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -139,7 +139,7 @@ func ExampleSetVersion() {
 	fmt.Println(string(bytes))
 
 	// Output:
-	// {"severity":"DEBUG","caller":"zl/zl.go:85","message":"INIT_LOGGER","version":"v1.0.0","console":"Severity: DEBUG, Output: ConsoleAndFile, File: ./log/example-set-version_v1.0.0.jsonl"}
+	// {"severity":"DEBUG","caller":"zl/zl.go:86","message":"INIT_LOGGER","version":"v1.0.0","console":"Severity: DEBUG, Output: ConsoleAndFile, File: ./log/example-set-version_v1.0.0.jsonl"}
 	// {"severity":"INFO","caller":"https://github.com/nkmr-jp/zl/blob/v1.0.0/example_test.go#L135","message":"INFO_MESSAGE","version":"v1.0.0","detail":"detail info xxxxxxxxxxxxxxxxx"}
 	// {"severity":"WARN","caller":"https://github.com/nkmr-jp/zl/blob/v1.0.0/example_test.go#L136","message":"WARN_MESSAGE","version":"v1.0.0","detail":"detail info xxxxxxxxxxxxxxxxx"}
 
@@ -268,6 +268,24 @@ func ExampleSetOmitKeys() {
 
 	// Output:
 	// {"function":"github.com/nkmr-jp/zl_test.ExampleSetOmitKeys"}
+}
+
+func ExampleSetFieldKey() {
+	setupForExampleTest()
+
+	zl.SetOutputByString("Console")
+	zl.SetStdout()
+	zl.SetOmitKeys(
+		zl.LevelKey, zl.LoggerKey, zl.TimeKey,
+		zl.CallerKey, zl.VersionKey, zl.HostnameKey, zl.StacktraceKey, zl.PIDKey,
+	)
+	zl.SetFieldKey(zl.MessageKey, "msg")
+	zl.SetFieldKey(zl.FunctionKey, "fn")
+	zl.Init()
+	zl.Info("INFO_MESSAGE")
+
+	// Output:
+	// {"fn":"github.com/nkmr-jp/zl_test.ExampleSetFieldKey","msg":"INFO_MESSAGE"}
 }
 
 func ExampleError() {

--- a/options.go
+++ b/options.go
@@ -188,6 +188,9 @@ func SetOmitKeys(key ...Key) {
 
 // SetFieldKey is changes the key of the default field.
 func SetFieldKey(key Key, val string) {
+	if key == "" || val == "" {
+		return
+	}
 	fieldKeys[key] = val
 }
 

--- a/options.go
+++ b/options.go
@@ -186,6 +186,11 @@ func SetOmitKeys(key ...Key) {
 	omitKeys = key
 }
 
+// SetFieldKey is changes the key of the default field.
+func SetFieldKey(key Key, val string) {
+	fieldKeys[key] = val
+}
+
 // SetStdout is changes the console log output from stderr to stdout.
 func SetStdout() {
 	isStdOut = true

--- a/options_test.go
+++ b/options_test.go
@@ -67,8 +67,21 @@ func TestSetLevelByString(t *testing.T) {
 	}
 }
 
-func TestSetSeparator(t *testing.T) {
+func TestSetFieldKey(t *testing.T) {
+	SetFieldKey(FunctionKey, "func")
+	SetFieldKey(StacktraceKey, "stack_trace")
+	assert.Equal(t,
+		map[Key]string{
+			FunctionKey:   "func",
+			StacktraceKey: "stack_trace",
+		},
+		fieldKeys,
+	)
 	ResetGlobalLoggerSettings()
+}
+
+func TestSetSeparator(t *testing.T) {
 	SetSeparator(":")
 	assert.Equal(t, ":", separator)
+	ResetGlobalLoggerSettings()
 }

--- a/options_test.go
+++ b/options_test.go
@@ -70,6 +70,8 @@ func TestSetLevelByString(t *testing.T) {
 func TestSetFieldKey(t *testing.T) {
 	SetFieldKey(FunctionKey, "func")
 	SetFieldKey(StacktraceKey, "stack_trace")
+	SetFieldKey(CallerKey, "")
+	SetFieldKey("", "abc")
 	assert.Equal(t,
 		map[Key]string{
 			FunctionKey:   "func",

--- a/zl.go
+++ b/zl.go
@@ -36,6 +36,7 @@ var (
 	callerEncoder  zapcore.CallerEncoder
 	consoleFields  = []string{consoleFieldDefault}
 	omitKeys       []Key
+	fieldKeys      = make(map[Key]string)
 	isStdOut       bool
 	separator      = " "
 	pid            int
@@ -88,13 +89,13 @@ func Init() {
 
 func newEncoderConfig() *zapcore.EncoderConfig {
 	enc := zapcore.EncoderConfig{
-		MessageKey:     string(MessageKey),
-		LevelKey:       string(LevelKey),
-		TimeKey:        string(TimeKey),
-		NameKey:        string(LoggerKey),
-		CallerKey:      string(CallerKey),
-		FunctionKey:    string(FunctionKey),
-		StacktraceKey:  string(StacktraceKey),
+		MessageKey:     fieldKey(MessageKey),
+		LevelKey:       fieldKey(LevelKey),
+		TimeKey:        fieldKey(TimeKey),
+		NameKey:        fieldKey(LoggerKey),
+		CallerKey:      fieldKey(CallerKey),
+		FunctionKey:    fieldKey(FunctionKey),
+		StacktraceKey:  fieldKey(StacktraceKey),
 		EncodeLevel:    zapcore.CapitalLevelEncoder,
 		EncodeTime:     zapcore.RFC3339NanoTimeEncoder,
 		EncodeDuration: zapcore.StringDurationEncoder,
@@ -102,6 +103,14 @@ func newEncoderConfig() *zapcore.EncoderConfig {
 	}
 	setOmitKeys(&enc)
 	return &enc
+}
+
+func fieldKey(key Key) string {
+	value, ok := fieldKeys[key]
+	if !ok {
+		return string(key)
+	}
+	return value
 }
 
 // See https://pkg.go.dev/go.uber.org/zap
@@ -270,6 +279,7 @@ func ResetGlobalLoggerSettings() {
 	callerEncoder = nil
 	consoleFields = []string{consoleFieldDefault}
 	omitKeys = nil
+	fieldKeys = make(map[Key]string)
 	isStdOut = false
 	separator = " "
 	fileName = ""


### PR DESCRIPTION
This PR introduces a new function, SetFieldKey, which allows changing the key of the default field. It also includes tests for this new function and an example of its usage. The function prevents empty keys or values. The PR also includes minor changes in other files to accommodate this new function.
